### PR TITLE
Add initial IATO.V7 Lean formalisation and documentation (core models and invariants)

### DIFF
--- a/IATO/V7/Architecture.lean
+++ b/IATO/V7/Architecture.lean
@@ -1,0 +1,27 @@
+import Mathlib.Order.Hom.CompleteLattice
+import Mathlib.Order.GaloisConnection
+import Mathlib.Tactic
+import IATO.V7.Basic
+
+namespace IATO.V7
+
+variable {α : Type _} [DecidableEq α]
+
+def pairwiseDisjointDeps (deps : List (DepSet α)) : Prop :=
+  List.Pairwise Disjoint deps
+
+def architectureSecure (deps : List (DepSet α)) : Prop :=
+  pairwiseDisjointDeps deps
+
+theorem architectureSecure_of_pairwise (deps : List (DepSet α)) :
+    pairwiseDisjointDeps deps → architectureSecure deps := by
+  intro h
+  exact h
+
+theorem secure_under_refinement (deps : List (DepSet α))
+    (policyRefine : DepSet α →o DepSet α)
+    (hSec : architectureSecure deps) : architectureSecure (deps.map policyRefine) := by
+  -- TODO(proof): secure_under_refinement — show Pairwise Disjoint preserved by monotone policy refinement.
+  admit
+
+end IATO.V7

--- a/IATO/V7/Basic.lean
+++ b/IATO/V7/Basic.lean
@@ -1,0 +1,29 @@
+import Mathlib.Order.Lattice
+import Mathlib.Data.Finset.Lattice
+import Mathlib.Tactic
+
+/-!
+Import DAG:
+Basic
+├─ Mathlib.Order.Lattice
+├─ Mathlib.Data.Finset.Lattice
+└─ Mathlib.Tactic
+-/
+
+namespace IATO.V7
+
+class SecurityLabel (α : Type _) extends CompleteLattice α
+
+abbrev DepSet (α : Type _) := Finset α
+
+abbrev CanFlow {α : Type _} [LE α] (a b : α) : Prop := a ≤ b
+
+theorem depSet_disjoint_separation {α : Type _} [DecidableEq α]
+    (s t : DepSet α) : Disjoint s t ↔ s ∩ t = (∅ : DepSet α) := by
+  simpa [Finset.disjoint_left] using Finset.disjoint_iff_inter_eq_empty
+
+theorem deps_join_monotone_left {α : Type _} [Sup α] [LE α] [SemilatticeSup α] (a b : α) :
+    a ≤ a ⊔ b := by
+  exact le_sup_left
+
+end IATO.V7

--- a/IATO/V7/ComplianceGalois.lean
+++ b/IATO/V7/ComplianceGalois.lean
@@ -1,0 +1,23 @@
+import Mathlib.Order.GaloisConnection
+import Mathlib.Tactic
+
+namespace IATO.V7
+
+structure ExecState where
+  ctl : Nat
+  ok : Bool
+
+structure ControlEvidence where
+  reqCtl : Nat
+
+
+def α : ExecState → ControlEvidence := fun s => ⟨s.ctl⟩
+
+def γ : ControlEvidence → Set ExecState := fun e => {s | e.reqCtl ≤ s.ctl}
+
+theorem compliance_gc : GaloisConnection α γ := by
+  intro s e
+  -- TODO(proof): compliance_gc — prove α/γ adjunction between control abstraction and concretization.
+  admit
+
+end IATO.V7

--- a/IATO/V7/ConflictClosure.lean
+++ b/IATO/V7/ConflictClosure.lean
@@ -1,0 +1,25 @@
+import Mathlib.Order.FixedPoints
+import Mathlib.Tactic
+import IATO.V7.Basic
+
+namespace IATO.V7
+
+variable {α : Type _} [DecidableEq α]
+
+def ConflictClosure : DepSet α →o DepSet α where
+  toFun s := s
+  monotone' := by intro a b h; simpa using h
+
+def lfp_conflict_closure : DepSet α := OrderHom.lfp ConflictClosure
+
+theorem closure_extensive (s : DepSet α) : s ⊆ ConflictClosure s := by
+  intro x hx
+  simpa [ConflictClosure] using hx
+
+theorem closure_monotone : Monotone (ConflictClosure : DepSet α → DepSet α) := by
+  simpa using ConflictClosure.monotone
+
+theorem closure_idempotent (s : DepSet α) : ConflictClosure (ConflictClosure s) = ConflictClosure s := by
+  rfl
+
+end IATO.V7

--- a/IATO/V7/NonInterference.lean
+++ b/IATO/V7/NonInterference.lean
@@ -1,0 +1,37 @@
+import Mathlib.Order.Relation
+import Mathlib.Data.Rel
+import Mathlib.Tactic
+
+namespace IATO.V7
+
+structure TransitionSystem (State : Type _) where
+  step : State → State → Prop
+
+variable {State Domain Obs : Type _}
+
+abbrev obsView (view : Domain → State → Obs) (d : Domain) (s : State) : Obs := view d s
+
+abbrev lowEq (view : Domain → State → Obs) (d : Domain) (s₁ s₂ : State) : Prop :=
+  obsView view d s₁ = obsView view d s₂
+
+abbrev output_consistency (view : Domain → State → Obs) : Prop :=
+  ∀ d s₁ s₂, lowEq view d s₁ s₂ → obsView view d s₁ = obsView view d s₂
+
+abbrev step_consistency (T : TransitionSystem State) (view : Domain → State → Obs) : Prop :=
+  ∀ d s₁ s₂ s₁' s₂', lowEq view d s₁ s₂ → T.step s₁ s₁' → T.step s₂ s₂' → lowEq view d s₁' s₂'
+
+abbrev local_respect (T : TransitionSystem State) (view : Domain → State → Obs) : Prop :=
+  ∀ d s s', T.step s s' → lowEq view d s s'
+
+theorem nonInterference
+    (T : TransitionSystem State)
+    (view : Domain → State → Obs)
+    (hOut : output_consistency view)
+    (hStep : step_consistency T view)
+    (hLocal : local_respect T view) :
+    ∀ d s₁ s₂ s₁' s₂', Relation.TransGen T.step s₁ s₁' → Relation.TransGen T.step s₂ s₂' →
+      lowEq view d s₁ s₂ → lowEq view d s₁' s₂' := by
+  -- TODO(proof): nonInterference — lift unwinding obligations over Relation.TransGen closures.
+  admit
+
+end IATO.V7

--- a/IATO/V7/RMETransitions.lean
+++ b/IATO/V7/RMETransitions.lean
@@ -1,0 +1,35 @@
+import IATO.V7.NonInterference
+import Mathlib.Order.Hom.CompleteLattice
+import Mathlib.Tactic
+
+namespace IATO.V7
+
+inductive EL where | EL0 | EL1 | EL2 | EL3 deriving DecidableEq
+
+structure MachineWorld where
+  el : EL
+  realm_id : Nat
+  secure_state : Bool
+
+inductive RMEStep : MachineWorld → MachineWorld → Prop
+  | realm_entry (s : MachineWorld) : RMEStep s { s with el := EL.EL3, secure_state := true }
+  | realm_exit (s : MachineWorld) : RMEStep s { s with el := EL.EL1, secure_state := false }
+  | switch_realm (s : MachineWorld) (rid : Nat) : RMEStep s { s with realm_id := rid }
+  | stay (s : MachineWorld) : RMEStep s s
+
+def realmObserverView (d : Nat) (s : MachineWorld) : EL × Bool :=
+  if s.realm_id = d then (s.el, s.secure_state) else (EL.EL0, false)
+
+theorem realm_entry_preserves_lowEq (d : Nat) (s : MachineWorld) :
+    lowEq realmObserverView d s { s with el := EL.EL3, secure_state := true } := by
+  -- TODO(proof): realm_entry_preserves_lowEq — prove observer-equivalence side conditions for matching realm.
+  admit
+
+def secureLift : MachineWorld →o MachineWorld where
+  toFun s := { s with secure_state := true }
+  monotone' := by
+    intro a b hab
+    -- TODO(proof): secureLift.monotone — instantiate order on MachineWorld and show monotonicity.
+    admit
+
+end IATO.V7

--- a/IATO/V7/Scanner.lean
+++ b/IATO/V7/Scanner.lean
@@ -1,0 +1,40 @@
+import Mathlib.Data.Finset.Lattice
+import Mathlib.Logic.Function.Basic
+import Mathlib.Tactic
+import IATO.V7.Basic
+
+namespace IATO.V7
+
+structure LegacyWorker (Domain α : Type _) where
+  domain : Domain
+  deps : DepSet α
+
+structure ScanReport (Domain α : Type _) where
+  workers : List (LegacyWorker Domain α)
+  conflicts : List (DepSet α × DepSet α)
+
+def scanLegacy {Domain α : Type _} [DecidableEq α] (w : LegacyWorker Domain α) : DepSet α := w.deps
+
+def scanAll {Domain α : Type _} [DecidableEq α] (ws : List (LegacyWorker Domain α)) : List (DepSet α) :=
+  ws.map scanLegacy
+
+def conflicts {α : Type _} [DecidableEq α] (xs : List (DepSet α)) : List (DepSet α × DepSet α) :=
+  xs.bind (fun x => xs.filterMap (fun y => if Disjoint x y then none else some (x, y)))
+
+def parseDomain {Domain : Type _} (f : Domain → Domain) := f
+
+theorem scanLegacy_sound {Domain α : Type _} [DecidableEq α] (w : LegacyWorker Domain α) :
+    scanLegacy w = w.deps := by rfl
+
+theorem scanAll_incompat_mono {Domain α : Type _} [DecidableEq α]
+    (ws₁ ws₂ : List (LegacyWorker Domain α))
+    (hsub : ws₁ <+ ws₂) :
+    (scanAll ws₁).length ≤ (scanAll ws₂).length := by
+  -- TODO(proof): scanAll_incompat_mono — prove scan length monotonic under list embedding.
+  admit
+
+theorem parseDomain_idem {Domain : Type _} (f : Domain → Domain)
+    (h : Function.Idempotent f) : Function.Idempotent (parseDomain f) := by
+  simpa [parseDomain] using h
+
+end IATO.V7

--- a/IATO/V7/SecurityLattice.lean
+++ b/IATO/V7/SecurityLattice.lean
@@ -1,0 +1,27 @@
+import IATO.V7.Basic
+import Mathlib.Tactic
+
+namespace IATO.V7
+
+abbrev SecurityProduct (Lconf Lint : Type _) := Lconf × Lint
+
+instance {Lconf Lint : Type _} [CompleteLattice Lconf] [CompleteLattice Lint] :
+    CompleteLattice (SecurityProduct Lconf Lint) := inferInstance
+
+instance {Lconf Lint : Type _} [CompleteLattice Lconf] [CompleteLattice Lint] :
+    SecurityLabel (SecurityProduct Lconf Lint) where
+
+ theorem flow_trans {Lconf Lint : Type _} [CompleteLattice Lconf] [CompleteLattice Lint]
+    (a b c : SecurityProduct Lconf Lint) : CanFlow a b → CanFlow b c → CanFlow a c := by
+  intro hab hbc
+  exact le_trans hab hbc
+
+theorem join_min_upper {Lconf Lint : Type _} [CompleteLattice Lconf] [CompleteLattice Lint]
+    (a b : SecurityProduct Lconf Lint) : a ≤ a ⊔ b := by
+  exact le_sup_left
+
+theorem meet_max_lower {Lconf Lint : Type _} [CompleteLattice Lconf] [CompleteLattice Lint]
+    (a b : SecurityProduct Lconf Lint) : a ⊓ b ≤ a := by
+  exact inf_le_left
+
+end IATO.V7

--- a/IATO/V7/Worker.lean
+++ b/IATO/V7/Worker.lean
@@ -1,0 +1,32 @@
+import Mathlib.Order.Monotone.Basic
+import Mathlib.Order.Relation
+import Mathlib.Data.Rel
+import Mathlib.Tactic
+import IATO.V7.Basic
+
+namespace IATO.V7
+
+structure Worker (Domain α : Type _) where
+  domain : Domain
+  deps : DepSet α
+
+structure Step (σ : Type _) where
+  run : σ → σ → Prop
+
+abbrev lowEqW {σ Domain Obs : Type _} (view : Domain → σ → Obs) (d : Domain) (s₁ s₂ : σ) : Prop :=
+  view d s₁ = view d s₂
+
+def locallyRespecting {σ Domain Obs α : Type _} (w : Worker Domain α)
+    (st : Step σ) (view : Domain → σ → Obs) : Prop :=
+  ∀ s s', st.run s s' → lowEqW view w.domain s s'
+
+def compose {α : Type _} [SemilatticeSup α] [OrderBot α] (ws : List (Worker Unit α)) : α :=
+  ws.foldl (fun acc w => acc ⊔ (w.deps.sup id)) ⊥
+
+theorem compose_deps_upper_bound {α : Type _} [SemilatticeSup α] [OrderBot α]
+    (ws : List (Worker Unit α)) (x : α)
+    (hx : ∀ w ∈ ws, w.deps.sup id ≤ x) : compose ws ≤ x := by
+  -- TODO(proof): compose_deps_upper_bound — establish foldl sup upper-bound induction.
+  admit
+
+end IATO.V7

--- a/README.md
+++ b/README.md
@@ -1,3 +1,71 @@
+# ARM Virtualisation Execution Correctness
+
+This repository includes an ARM virtualisation and execution-correctness scaffold for Azure Cobalt-class Neoverse infrastructure.  The model treats execution correctness as a register-level property over the global state:
+
+```text
+S = ⟨S_EL2, S_Stage2, S_SVE2, S_QEMU, S_KVM, S_Microarch⟩
+```
+
+Component state is explicit:
+
+```text
+S_EL2       = ⟨HCR_EL2, VTTBR_EL2, VTCR_EL2, DAIF, ELR_EL2, SPSR_EL2⟩
+S_Stage2    = ⟨VMID, IPA→PA_table, fault_log⟩
+S_SVE2      = ⟨Z₀..₃₁, P₀..₁₅, FFR, VL⟩
+S_QEMU      = ⟨Σ_stable, ID_reg_mask, VCPU_cfg⟩
+S_KVM       = ⟨S_VCPU, exit_reason, run_state⟩
+S_Microarch = ⟨BTB_state, BHB_state, LLC_state, RSB_state, pipeline_state⟩
+```
+
+No component state is inferred, defaulted, or implicitly carried across VM entry or VM exit. Every transition is explicit, bounded, and verifiable at the named register, table, or architectural state element.
+
+## Correctness Definition
+
+```text
+CORRECT(S) ⟺
+  Arch_Correct(S)
+  ∧ Isolation_Correct(S)
+  ∧ Microarch_Noninterference(S)
+  ∧ Projection_Correct(S)
+```
+
+- `Arch_Correct(S)`: `S_EL2`, `S_Stage2`, `S_SVE2`, and `S_KVM` transitions conform to ARM ARM DDI0487K and KVM/ARM64 behaviour.
+- `Isolation_Correct(S)`: no guest observes another guest or EL2 through architectural instruction or exception mechanisms.
+- `Microarch_Noninterference(S)`: cache timing, `BTB_state`, `BHB_state`, `RSB_state`, and `pipeline_state` do not reveal protected memory access patterns or branch behaviour.
+- `Projection_Correct(S)`: `Σ_stable ⊆ Σ_host`; QEMU exposes only fleet-stable architectural features through ID register masking.
+
+## Core Invariants
+
+```text
+I₁:  HCR_EL2.VM = 1               ∀ S_VCPU ∈ {running, vmexit}
+I₂:  VTCR_EL2.PS ≥ host_PA_range  at VCPU creation; not modifiable thereafter
+I₃:  VL ∈ {128, 256, 512, 1024, 2048} ∧ VL ≤ VL_max(substrate)
+I₄:  VL invariant ∀ t ≥ t_configured
+I₅:  Σ_stable = Σ_host ∩ Σ_guest   computed once at VCPU creation
+I₆:  SVE_SAVE_EXTRA: Z then P then FFR; violation is a correctness fault
+I₇:  DAIF restored atomically at EL1 re-entry; partial restoration not permitted
+I₈:  VMID(VTTBR_EL2) unique across all S_VCPU = running instances
+I₉:  (V3/RME) No Stage-2 PTE maps Realm or Secure PAS
+I₁₀: BRBE disabled or context-saved before each VM entry unless guest BRBE granted
+I₁₁: RDVL result × 8 = configured VL; divergence is an observable fault
+I₁₂: MTE3 VCPU not migrated to host where MTE3 absent; silent downgrade rejected
+I₁₃: QARMA3 PAC keys not masked from guest on V3-homogeneous fleet only
+I₁₄: CLEARBHB issued at EL2 entry on N2/V3 hosts regardless of CSV2 field value
+```
+
+## Correctness Artefacts
+
+- [`el2_control.md`](el2_control.md): `HCR_EL2`, `DAIF`, VM entry/exit, EL2 save/restore, `ZCR_EL2`.
+- [`stage2_isolation.md`](stage2_isolation.md): `VTTBR_EL2`, `VTCR_EL2`, `VMID`, `IPA→PA_table`, Stage-2 fault invariants.
+- [`sve2_execution.md`](sve2_execution.md): `Z₀..Z₃₁`, `P₀..P₁₅`, `FFR`, `VL`, SVE2 feature detection, save/restore ordering.
+- [`kvm_lifecycle.md`](kvm_lifecycle.md): `S_VCPU`, `KVM_RUN`, `KVM_SET_ONE_REG`, `KVM_GET_ONE_REG`, migration constraints.
+- [`qemu_projection.md`](qemu_projection.md): `Σ_host ∩ Σ_guest → Σ_stable`, ID register masking, heterogeneous substrate projection.
+- [`threat_model.md`](threat_model.md): Spectre-v1/v2/BHB, Meltdown, cache timing, RSB underflow, BRBE, pipeline observability.
+- [`cobalt_constraints.md`](cobalt_constraints.md): Azure Cobalt 100/200, Neoverse N2/V3, PAC, MTE, RME constraints.
+- [`correctness_model.md`](correctness_model.md): full invariant set, correctness conjunction, NTT cryptographic execution constraints.
+
+---
+
 ### Control Validation — v1.0.0
 
 **System Classification**

--- a/cobalt_constraints.md
+++ b/cobalt_constraints.md
@@ -1,0 +1,65 @@
+# Azure Cobalt ARM Constraints
+
+## Scope
+
+This file records the Azure Cobalt 100 and Azure Cobalt 200 substrate constraints used by `Σ_host`, `Σ_stable`, SVE2 vector-length bounds, PAC compatibility, MTE migration, and RME Stage-2 invariants.
+
+## Azure Cobalt 100: Neoverse N2 / ARMv8.5-A
+
+ID register constraints:
+
+```text
+ID_AA64PFR0_EL1.SVE    ≠ 0b0000   → SVE present
+ID_AA64ZFR0_EL1.SVEver = 0b0001   → SVE2 confirmed
+ID_AA64PFR0_EL1.CSV2   = 0b0010   → FEAT_CSV2_2 present; Spectre-BHB HW mitigation active
+ID_AA64PFR1_EL1.MTE    = 0b0011   → MTE2; async and sync tag fault modes
+ID_AA64ISAR1_EL1.APA   = 0b0001   → PAC with QARMA5 cipher
+ID_AA64DFR0_EL1.BRBE  ≠ 0         → BRBE present; isolation obligations apply
+```
+
+SVE2 vector length ceiling on N2 is 256 bits. Any VCPU requesting `VL > 256` is rejected at `KVM_SET_ONE_REG(KVM_REG_ARM64_SVE_VLS)`.
+
+Azure Boost NVMe and network MMIO ranges are Stage-2 mapped as Device-nGnRE. No Normal-cacheable Stage-2 mapping is used for Azure Boost device ranges.
+
+## Azure Cobalt 200: Neoverse V3 / ARMv9.2-A
+
+ID register constraints:
+
+```text
+ID_AA64ZFR0_EL1.SVEver  = 0b0001  → SVE2 present; 512-bit VL max
+ID_AA64ISAR2_EL1.APA3   = 0b0001  → PAC with QARMA3 cipher
+ID_AA64PFR1_EL1.MTE     = 0b0100  → MTE3; asymmetric tagging
+ID_AA64PFR0_EL1.RME    ≠ 0        → Realm Management Extension present
+ID_AA64PFR1_EL1.BT     ≠ 0        → Branch Target Identification active
+```
+
+## PAC QARMA3 Transition
+
+QARMA3 produces different PAC field values than QARMA5 for the same pointer and key input. PAC key registers including `APIAKey_EL1`, `APDAKey_EL1`, and `APGAKey_EL1` are EL2-owned for save/restore purposes. A `Σ_stable` configuration that exposes QARMA3 must be V3-homogeneous; otherwise invariant `I₁₃` is violated.
+
+## MTE3 Save/Restore
+
+MTE3 VCPU state includes:
+
+```text
+Save:
+  TFSRE0_EL1, TFSR_EL1
+  RGSR_EL1, GCR_EL1
+  MTE tag memory region, size = data_region / 16
+  SCTLR_EL1.{TCF, TCF0}
+
+Restore:
+  tag memory restored before SCTLR_EL1 tag checking is re-enabled
+```
+
+A VCPU with MTE3 state migrated to a host where `ID_AA64PFR1_EL1.MTE ≠ 0b0100` is rejected under `I₁₂`; silent downgrade to MTE2 is invalid.
+
+## RME / CCA Normal-World Constraints
+
+The repository operates in the Normal world. On V3/RME hosts:
+
+```text
+I_RME_1: No VTTBR_EL2 entry references Realm PAS granules
+I_RME_2: No VTTBR_EL2 entry references Secure PAS granules
+I_RME_3: GPT at EL3 enforces PAS partitioning; Stage-2 faults on Realm/Secure granules are GPT-enforced
+```

--- a/correctness_model.md
+++ b/correctness_model.md
@@ -1,0 +1,101 @@
+# Global Execution Correctness Model
+
+## Global State
+
+```text
+S = ⟨S_EL2, S_Stage2, S_SVE2, S_QEMU, S_KVM, S_Microarch⟩
+```
+
+```text
+S_EL2       = ⟨HCR_EL2, VTTBR_EL2, VTCR_EL2, DAIF, ELR_EL2, SPSR_EL2⟩
+S_Stage2    = ⟨VMID, IPA→PA_table, fault_log⟩
+S_SVE2      = ⟨Z₀..₃₁, P₀..₁₅, FFR, VL⟩
+S_QEMU      = ⟨Σ_stable, ID_reg_mask, VCPU_cfg⟩
+S_KVM       = ⟨S_VCPU, exit_reason, run_state⟩
+S_Microarch = ⟨BTB_state, BHB_state, LLC_state, RSB_state, pipeline_state⟩
+```
+
+No component is implicit across VM entry or VM exit. Every state transition names the register, table, feature set, or microarchitectural state it affects.
+
+## Correctness Definition
+
+```text
+CORRECT(S) ⟺
+  Arch_Correct(S)
+  ∧ Isolation_Correct(S)
+  ∧ Microarch_Noninterference(S)
+  ∧ Projection_Correct(S)
+```
+
+- `Arch_Correct(S)`: `S_EL2`, `S_Stage2`, `S_SVE2`, and `S_KVM` transitions conform to ARM ARM and KVM/ARM64 behaviour.
+- `Isolation_Correct(S)`: guests cannot observe other guests or EL2 through architectural instruction or exception mechanisms.
+- `Microarch_Noninterference(S)`: `BTB_state`, `BHB_state`, `LLC_state`, `RSB_state`, and `pipeline_state` do not reveal protected state.
+- `Projection_Correct(S)`: `Σ_stable` is a behaviourally stable subset of `Σ_host` across the deployment fleet.
+
+## Full Invariant Set
+
+```text
+I₁:  HCR_EL2.VM = 1               ∀ S_VCPU ∈ {running, vmexit}
+I₂:  VTCR_EL2.PS ≥ host_PA_range  at VCPU creation; not modifiable thereafter
+I₃:  VL ∈ {128, 256, 512, 1024, 2048} ∧ VL ≤ VL_max(substrate)
+I₄:  VL invariant ∀ t ≥ t_configured
+I₅:  Σ_stable = Σ_host ∩ Σ_guest   computed once at VCPU creation
+I₆:  SVE_SAVE_EXTRA: Z then P then FFR; violation is a correctness fault
+I₇:  DAIF restored atomically at EL1 re-entry; partial restoration not permitted
+I₈:  VMID(VTTBR_EL2) unique across all S_VCPU = running instances
+I₉:  (V3/RME) No Stage-2 PTE maps Realm or Secure PAS
+I₁₀: BRBE disabled or context-saved before each VM entry unless guest BRBE granted
+I₁₁: RDVL result × 8 = configured VL; divergence is an observable fault
+I₁₂: MTE3 VCPU not migrated to host where MTE3 absent; silent downgrade rejected
+I₁₃: QARMA3 PAC keys not masked from guest on V3-homogeneous fleet only
+I₁₄: CLEARBHB issued at EL2 entry on N2/V3 hosts regardless of CSV2 field value
+```
+
+## Architectural Correctness
+
+`Arch_Correct(S)` requires:
+
+- `HCR_EL2.VM`, `HCR_EL2.RW`, `HCR_EL2.TSC`, `HCR_EL2.TGE`, `HCR_EL2.TWI`, `HCR_EL2.TWE`, and `HCR_EL2.VSE` satisfy EL2 invariants.
+- `VTTBR_EL2.BADDR`, `VTTBR_EL2.VMID`, and `VTCR_EL2` fields match the declared Stage-2 configuration.
+- `ZCR_EL2.LEN = (VL / 128) - 1` and `RDVL Xn, #1` reports `VL / 8`.
+- `KVM_RUN`, `KVM_GET_ONE_REG`, and `KVM_SET_ONE_REG` are used only in legal `S_VCPU` states.
+
+## Isolation Correctness
+
+`Isolation_Correct(S)` requires Stage-2 faults for unmapped IPA, Device-nGnRE or Device-nGnRnE mappings for device MMIO IPA, VMID uniqueness, no guest mapping to EL2-private PA ranges, and no Normal-world Stage-2 PTE to Realm PAS or Secure PAS on RME hosts.
+
+## Microarchitectural Non-Interference
+
+```text
+∀ attacker VCPU A, victim VCPU B:
+  obs(S_Microarch | execution of B) is independent of B's protected memory contents
+```
+
+This includes Spectre-v1, Spectre-v2, Spectre-BHB, Meltdown-class speculative load concerns, cache timing, RSB underflow, BRBE exposure, and pipeline latency.
+
+## Projection Correctness
+
+`Projection_Correct(S)` requires:
+
+```text
+Σ_host ∩ Σ_guest → Σ_stable
+Σ_stable ⊆ Σ_host
+```
+
+QEMU masks `ID_AA64PFR0_EL1`, `ID_AA64ZFR0_EL1`, `ID_AA64ISAR1_EL1`, `ID_AA64ISAR2_EL1`, and `ID_AA64PFR1_EL1` fields not present in `Σ_stable`.
+
+## NTT Cryptographic Execution Constraints
+
+For SVE2 NTT implementations targeting CRYSTALS-Kyber and CRYSTALS-Dilithium:
+
+```text
+- NTT butterfly uses SQRDMLAH and MUL Zd.H, Zn.H, Zm.H[idx]
+- P₀..P₃ gate active lanes
+- FFR is not used in the NTT inner loop
+- No data-dependent branch occurs in the NTT path
+- No data-dependent coefficient-array memory traversal occurs
+- Transform length = k × VL, with k fixed at initialisation
+- ∀ inputs of equal length, execution time is identical
+```
+
+The NTT constraint depends on invariant `I₄`; if `VL` changes after configuration, transform length and constant-time behaviour are no longer stable.

--- a/el2_control.md
+++ b/el2_control.md
@@ -1,0 +1,74 @@
+# EL2 Control Correctness
+
+## Scope
+
+`S_EL2 = ⟨HCR_EL2, VTTBR_EL2, VTCR_EL2, DAIF, ELR_EL2, SPSR_EL2⟩` is the constrained enforcement layer for guest execution. EL2 is not modelled as trusted; it is modelled as the architectural privilege level that enforces traps, Stage-2 translation activation, VM entry, VM exit, and exception-level transitions.
+
+## HCR_EL2 Invariants
+
+The following `HCR_EL2` fields are hard invariants for every VCPU in `S_VCPU ∈ {running, vmexit}`:
+
+| Field | Enforced Value | Correctness obligation |
+| --- | --- | --- |
+| `HCR_EL2.VM` | `1` | Stage-2 translation is active; `HCR_EL2.VM = 0` while running is invalid. |
+| `HCR_EL2.RW` | `1` | EL1 executes AArch64; AArch32 guest execution is outside scope. |
+| `HCR_EL2.TSC` | `1` | Guest `SMC` traps to EL2; EL1 cannot invoke EL3 directly. |
+| `HCR_EL2.TGE` | `0` | Guest owns EL1; `TGE = 1` is incompatible with KVM guest execution. |
+| `HCR_EL2.TWI` | per-VCPU | WFI trap policy is declared at VCPU creation, not changed at runtime. |
+| `HCR_EL2.TWE` | per-VCPU | WFE trap policy is declared at VCPU creation, not changed at runtime. |
+| `HCR_EL2.VSE` | EL2-controlled | Virtual SError injection is explicit EL2 state. |
+
+Invariant `I₁` is therefore:
+
+```text
+HCR_EL2.VM = 1 ∀ S_VCPU ∈ {running, vmexit}
+```
+
+## VM Entry Preconditions
+
+`KVM_RUN` may enter the guest only when:
+
+```text
+pre(VM_ENTRY):
+  HCR_EL2.VM = 1
+  ∧ VTTBR_EL2.BADDR points to valid Stage-2 root table
+  ∧ VTCR_EL2 fields consistent with IPA space declared at VCPU creation
+  ∧ SVE context: fully saved from prior exit OR zero-initialised on first entry
+  ∧ DAIF state: coherent with interrupt routing policy
+  ∧ S_VCPU ∈ {configured, vmexit}
+```
+
+`VTTBR_EL2.BADDR`, `VTCR_EL2`, `DAIF`, and `ZCR_EL2` are part of the entry contract; they are not inferred from KVM userspace configuration after entry begins.
+
+## VM Exit Semantics
+
+Every exit records `kvm_run->exit_reason` atomically with the VCPU state transition to `vmexit`.
+
+| Exit reason | Architectural cause |
+| --- | --- |
+| `KVM_EXIT_MMIO` | Stage-2 fault on device-mapped IPA. |
+| `KVM_EXIT_HVC` | Guest `HVC` instruction and hypercall dispatch. |
+| `KVM_EXIT_SYSTEM_EVENT` | PSCI call or system reset request. |
+| `KVM_EXIT_IRQ` | Virtual IRQ injection acknowledgement. |
+| `KVM_EXIT_EXCEPTION` | Unhandled synchronous exception at EL1. |
+
+Consuming EL1 register state without issuing a complete response for the recorded `exit_reason` is a partial exit-handling violation.
+
+## Save/Restore Obligations
+
+EL2-owned state saved unconditionally at every VM exit:
+
+```text
+{ HCR_EL2, VTTBR_EL2, VTCR_EL2,
+  SCTLR_EL2, TCR_EL2, MAIR_EL2,
+  SPSR_EL2, ELR_EL2, SP_EL2,
+  DAIF, ZCR_EL2 }
+```
+
+`DAIF` is restored atomically at EL1 re-entry. Restoring `DAIF.I` without `DAIF.F`, `DAIF.A`, and `DAIF.D` is a correctness violation under `I₇`.
+
+`ZCR_EL2.LEN = (VL / 128) - 1` is EL2-owned state. It bounds effective SVE vector length and is restored with EL2 state, not treated as an EL1-owned preference.
+
+## EL2 Entry Microarchitectural Obligations
+
+`CLEARBHB` is issued at every EL2 entry on Neoverse N2 and V3 hosts regardless of the value reported in `ID_AA64PFR0_EL1.CSV2`. RSB stuffing is required before any `RET`-based EL2 control flow executes. These obligations support `I₁₄` and the microarchitectural non-interference component of `CORRECT(S)`.

--- a/kvm_lifecycle.md
+++ b/kvm_lifecycle.md
@@ -1,0 +1,71 @@
+# KVM VCPU Lifecycle Correctness
+
+## Scope
+
+`S_KVM = ⟨S_VCPU, exit_reason, run_state⟩` models the KVM/ARM64 VCPU lifecycle, KVM interface obligations, and migration constraints. State transitions not listed here are illegal.
+
+## VCPU State Machine
+
+```text
+S_VCPU = ⟨created, configured, running, vmexit, migrating, destroyed⟩
+```
+
+Legal transitions:
+
+```text
+created     → configured   : KVM_SET_ONE_REG applied; VL negotiated; feature set finalised
+configured  → running      : KVM_RUN issued; VM entry preconditions satisfied
+running     → vmexit       : trap, fault, interrupt, HVC, or PSCI causes architectural exit
+vmexit      → running      : exit reason handled; KVM_RUN reissued
+vmexit      → migrating    : VCPU state serialised for live migration
+migrating   → configured   : VCPU state deserialised on target host; feature set re-validated
+configured  → destroyed    : VCPU fd closed; all associated state freed
+* → destroyed              : unrecoverable fault; immediate teardown
+```
+
+A VCPU in `running` cannot transition directly to `migrating`. A VCPU in `destroyed` has no valid successors.
+
+## KVM Interface Obligations
+
+| Interface | Correct usage |
+| --- | --- |
+| `KVM_CHECK_EXTENSION(KVM_CAP_ARM_SVE)` | Must return non-zero before any SVE VCPU is created. |
+| `KVM_SET_ONE_REG(KVM_REG_ARM64_SVE_VLS)` | Sets `VL`; valid only during `configured` state. |
+| `KVM_SET_ONE_REG(KVM_REG_ARM64_*)` | General VCPU register initialisation before running. |
+| `KVM_RUN` | Triggers VM entry and blocks until VM exit. |
+| `KVM_GET_ONE_REG` | Reads register state; valid in `vmexit` state. |
+
+`KVM_SET_ONE_REG` calls targeting SVE registers after the VCPU has entered `running` are rejected, not deferred or silently accepted.
+
+## VM Entry Coupling
+
+`configured → running` is valid only when the EL2 preconditions hold:
+
+```text
+HCR_EL2.VM = 1
+∧ VTTBR_EL2.BADDR points to valid Stage-2 root table
+∧ VTCR_EL2 fields match declared IPA space
+∧ SVE context saved or zero-initialised
+∧ DAIF coherent with interrupt routing
+```
+
+`KVM_RUN` is therefore coupled to `S_EL2`, `S_Stage2`, and `S_SVE2`; it is not a scheduler-only action.
+
+## Migration Constraints
+
+A live-migration serialisation contains:
+
+```text
+{ S_EL2, S_Stage2.VMID, S_SVE2, S_KVM.run_state,
+  all EL1 system registers,
+  MTE tag memory (if MTE enabled),
+  BRBE context (if BRBE enabled and guest-accessible) }
+```
+
+The target host must satisfy:
+
+```text
+Σ_stable(target) ⊆ Σ_stable(source)
+```
+
+Migration that drops architectural features, downgrades MTE3 to MTE2, or changes PAC semantics from QARMA3 to QARMA5 under a supposedly stable configuration is a correctness violation.

--- a/qemu_projection.md
+++ b/qemu_projection.md
@@ -1,0 +1,50 @@
+# QEMU Architectural Projection Correctness
+
+## Scope
+
+`S_QEMU = ⟨Σ_stable, ID_reg_mask, VCPU_cfg⟩` models QEMU as a bounded architectural projection layer for KVM/ARM64 execution. QEMU does not emulate missing features in this model; it exposes only fleet-stable features.
+
+## Projection Constraint
+
+```text
+Σ_host ∩ Σ_guest → Σ_stable
+```
+
+- `Σ_host`: physical Neoverse N2 or V3 feature set.
+- `Σ_guest`: feature set requested by VCPU configuration.
+- `Σ_stable`: features present on the host, exposed to the guest, and behaviourally identical across all valid hosts in the deployment fleet.
+
+Features in `Σ_host \ Σ_stable` are masked from the guest. Features in `Σ_guest \ Σ_host` are rejected at VCPU creation. Neither class is emulated.
+
+Invariant `I₅` is:
+
+```text
+Σ_stable = Σ_host ∩ Σ_guest computed once at VCPU creation
+```
+
+## ID Register Masking
+
+QEMU enforces `Σ_stable` through controlled ID register values:
+
+| Register | Controlled fields |
+| --- | --- |
+| `ID_AA64PFR0_EL1` | `SVE`, `GIC`, `RAS`, `DIT`, `CSV2` |
+| `ID_AA64ZFR0_EL1` | `SVEver`, `SHA3`, `SM4`, `F32MM`, `F64MM` |
+| `ID_AA64ISAR1_EL1` | `APA`, `API`, `GPA`, `GPI`, `LRCPC`, `DPB` |
+| `ID_AA64ISAR2_EL1` | `APA3`, `GPA3`, `RPRES` |
+| `ID_AA64PFR1_EL1` | `MTE`, `SSBS`, `BT`, `RNDs` |
+
+Fields outside `Σ_stable` are returned as `0b0000`. Guest feature detection must test architectural availability thresholds, not raw masked values as if they were host values.
+
+## Heterogeneous Substrate Projection
+
+| Substrate | ISA | Microarchitecture | SVE2 VL max | PAC cipher | Notable `Σ_host` additions |
+| --- | --- | --- | --- | --- | --- |
+| Azure Cobalt 100 | ARMv8.5-A | Neoverse N2 | 256-bit | QARMA5 | BRBE, MTE2, CSV2_2 |
+| Azure Cobalt 200 | ARMv9.2-A | Neoverse V3 | 512-bit | QARMA3 | MTE3, RME/CCA, BTI, FEAT_HBC |
+
+For a fleet spanning both substrates, `Σ_stable` excludes QARMA3 PAC, MTE3 asymmetric tagging, 512-bit SVE2 VL, and RME Realm PAS. These appear as `0b0000` in `ID_AA64*` registers for cross-substrate VCPU configurations.
+
+## Projection Correctness
+
+`Projection_Correct(S)` holds only when every exposed feature is present and behaviourally equivalent on every valid host in the fleet. Exposing QARMA3 to a mixed N2/V3 fleet, exposing 512-bit SVE2 VL to N2, or exposing RME Realm PAS to Normal-world guests violates projection correctness.

--- a/stage2_isolation.md
+++ b/stage2_isolation.md
@@ -1,0 +1,71 @@
+# Stage-2 Memory Isolation Correctness
+
+## Scope
+
+`S_Stage2 = ⟨VMID, IPA→PA_table, fault_log⟩` models hardware-enforced second-stage address translation for EL1/EL0 memory accesses. Stage-2 translation is not a software policy check; it is the MMU traversal controlled by `VTTBR_EL2`, `VTCR_EL2`, and the Stage-2 translation tables.
+
+## Translation Model
+
+```text
+IPA → PA
+```
+
+Every guest physical access that produces an IPA is retranslated by the Stage-2 MMU before a physical bus transaction. EL1 has no instruction that modifies `IPA→PA_table` and no visibility into EL2-owned Stage-2 mappings.
+
+## VTTBR_EL2
+
+`VTTBR_EL2` contains:
+
+- `BADDR[47:1]`: base physical address of the Stage-2 Level-0 or Level-1 root table.
+- `VMID[63:48]` or `VMID[55:48]`: width selected by `VTCR_EL2.VS`.
+
+`VMID(VTTBR_EL2)` uniqueness is invariant across all concurrently running VCPUs:
+
+```text
+I₈: VMID(VTTBR_EL2) unique across all S_VCPU = running instances
+```
+
+VMID reuse without `VMALLS12E1IS` is a correctness violation because stale Stage-2 TLB entries are VMID-tagged.
+
+## VTCR_EL2 Constraints
+
+| Field | Constraint |
+| --- | --- |
+| `T0SZ` | IPA address space size is `64 - T0SZ` bits and matches guest RAM layout. |
+| `SL0` | Starting level of Stage-2 walk is determined from `T0SZ` per ARM ARM Table D8-7. |
+| `IRGN0` | Inner cacheability for Stage-2 table walks. |
+| `ORGN0` | Outer cacheability for Stage-2 table walks. |
+| `SH0` | Shareability domain for Stage-2 table walks. |
+| `PS` | Output physical address size is no larger than the host PA range. |
+| `VS` | VMID width: `0` for 8-bit VMIDs or `1` for 16-bit VMIDs. |
+
+`VTCR_EL2.PS` is fixed at VCPU creation and supports:
+
+```text
+I₂: VTCR_EL2.PS ≥ host_PA_range at VCPU creation; not modifiable thereafter
+```
+
+## Isolation Invariants
+
+```text
+I_Stage2_1: ∀ guest IPA not in Stage-2 table → Stage-2 fault → EL2 trap
+I_Stage2_2: ∀ device MMIO IPA → Stage-2 PTE.MemAttr = nGnRE or nGnRnE
+I_Stage2_3: VMID(VTTBR_EL2) unique across all S_VCPU = running instances
+I_Stage2_4: No guest IPA maps to EL2-private PA regions
+I_Stage2_5: (on V3/RME hosts) No guest IPA maps to Realm PAS or Secure PAS
+```
+
+Device MMIO ranges, including Azure Boost NVMe and network datapaths, are represented as Device-nGnRE or Device-nGnRnE Stage-2 mappings. Normal-cacheable Stage-2 mappings are not used for Azure Boost device ranges.
+
+## RME / CCA Constraints
+
+On Neoverse V3 hosts with RME/CCA:
+
+```text
+I_RME_1: No VTTBR_EL2 entry references Realm PAS granules
+I_RME_2: No VTTBR_EL2 entry references Secure PAS granules
+I_RME_3: Granule Protection Table at EL3 enforces PAS partitioning;
+          Stage-2 faults on Realm/Secure granules are GPT-enforced
+```
+
+Stage-2 table faults involving Realm PAS or Secure PAS are GPT-enforced architectural events, not software assertions.

--- a/sve2_execution.md
+++ b/sve2_execution.md
@@ -1,0 +1,86 @@
+# SVE2 Register-File Execution Correctness
+
+## Scope
+
+`S_SVE2 = ⟨Z₀..₃₁, P₀..₁₅, FFR, VL⟩` is deterministic architectural state. SVE2 is modelled as vector-state execution, not as a performance optimisation.
+
+## Feature Detection Sequence
+
+Feature detection occurs once during VCPU creation:
+
+```text
+Step 1: Read ID_AA64PFR0_EL1.SVE
+        → if 0b0000: SVE absent; VCPU cannot be SVE-capable; halt
+
+Step 2: Read ID_AA64ZFR0_EL1.SVEver
+        → if != 0b0001: SVE2 absent; VCPU cannot use SVE2 instruction set; halt
+
+Step 3: Check KVM_CAP_ARM_SVE via ioctl(KVM_CHECK_EXTENSION)
+        → if 0: kernel does not support SVE virtualisation; halt
+
+Step 4: Negotiate VL via KVM_SET_ONE_REG(KVM_REG_ARM64_SVE_VLS)
+        → VL is fixed at this point; no subsequent modification permitted
+```
+
+Bypassing steps 1 through 3 before `KVM_SET_ONE_REG(KVM_REG_ARM64_SVE_VLS)` is a configuration error.
+
+## Register State
+
+| Component | Width | Correctness role |
+| --- | --- | --- |
+| `Z₀..Z₃₁` | `VL` bits each | 32 full-width vector registers. |
+| `P₀..P₁₅` | `VL/8` bits each | Predicate registers; one bit per byte lane. |
+| `FFR` | `VL/8` bits | First-Fault Register for fault-first loads. |
+| `VL` | scalar | Vector length in bits: `{128, 256, 512, 1024, 2048}`. |
+
+`VL` is invariant after configuration:
+
+```text
+I₃: VL ∈ {128, 256, 512, 1024, 2048} ∧ VL ≤ VL_max(substrate)
+I₄: VL invariant ∀ t ≥ t_configured
+```
+
+`ZCR_EL2.LEN = (VL / 128) - 1`; guest `ZCR_EL1.LEN` is clamped to `min(ZCR_EL1.LEN, ZCR_EL2.LEN)`.
+
+`RDVL Xn, #1` must return `VL / 8` bytes:
+
+```text
+I₁₁: RDVL result × 8 = configured VL; divergence is an observable fault
+```
+
+## Save/Restore Ordering
+
+`SVE_SAVE_EXTRA` save ordering is mandatory:
+
+```text
+SAVE:
+  1. Z₀..Z₃₁    (full VL-width; 32 × VL/8 bytes)
+  2. P₀..P₁₅    (VL/64 bytes each; 16 × VL/64 bytes total)
+  3. FFR         (VL/64 bytes; saved last)
+
+RESTORE:
+  1. FFR
+  2. P₀..P₁₅
+  3. Z₀..Z₃₁
+```
+
+Save-area size is allocated once at VCPU creation:
+
+```text
+(32 × VL/8) + (16 × VL/64) + (VL/64) bytes
+```
+
+Violation of this ordering is invariant `I₆` failure.
+
+## NTT Cryptographic Execution Constraints
+
+For CRYSTALS-Kyber / CRYSTALS-Dilithium NTT execution over SVE2:
+
+```text
+- NTT butterfly: SQRDMLAH, MUL Zd.H, Zn.H, Zm.H[idx]
+- Active lanes gated by P₀..P₃; FFR not used in NTT inner loop
+- No data-dependent branch in NTT execution path
+- No data-dependent memory access pattern in NTT coefficient array traversal
+- VL-invariance (I₄) is a prerequisite; transform length = k × VL; k fixed at initialisation
+- Constant-time assertion: ∀ inputs of equal length, execution time is identical
+```

--- a/threat_model.md
+++ b/threat_model.md
@@ -1,0 +1,54 @@
+# Microarchitectural Threat Model
+
+## Scope
+
+`S_Microarch = ⟨BTB_state, BHB_state, LLC_state, RSB_state, pipeline_state⟩` is not directly readable through architectural instructions, but it is observable through timing and predictor side effects. Correctness includes non-observability of protected state under adversarial probing.
+
+## Threat Classes
+
+### Spectre-v1: Bounds-Check Bypass
+
+Speculative execution past a bounds check can load an out-of-bounds address into cache. The resulting `LLC_state` delta may be observed by an attacker VCPU through Prime+Probe or Flush+Reload.
+
+### Spectre-v2: Branch Target Injection
+
+An attacker can poison `BTB_state` to redirect speculative EL2 indirect branches toward gadgets. Neoverse N2/V3 mitigation requires `FEAT_CSV2_2` support and explicit entry-path hardening. `CLEARBHB` is issued before the first speculative EL2 instruction.
+
+### Spectre-BHB
+
+Guest-controlled `BHB_state` can influence EL2 indirect branch prediction across privilege boundaries. `CLEARBHB` or `SMCCC_ARCH_WORKAROUND_3` is required at every EL2 entry; RSB stuffing alone is insufficient.
+
+### Meltdown-Class Privilege Boundary Loads
+
+Speculative reads of EL2-mapped physical memory from EL1 are mitigated by ensuring no EL2 PA range appears in Stage-2 mappings. EL1 page tables must not contain EL2 PA ranges at any privilege level.
+
+### Cache Timing Side Channels
+
+Neoverse N2/V3 LLC is not partitioned by VMID. Co-resident VCPUs may observe `LLC_state` through timing. VCPU pinning and co-residency constraints belong to scheduling policy; they are not assumed absent in the correctness model.
+
+### RSB Underflow
+
+`RSB_state` underflow can fall back to BTB-based return prediction. EL2 entry paths perform RSB stuffing before any `RET`-based EL2 control flow executes.
+
+### Pipeline State Observability
+
+`pipeline_state` affects execution latency. Constant-time constraints apply to EL2 paths that process guest-controlled data, including SVE2 predicate evaluation and Stage-2 fault handlers.
+
+## Non-Interference Property
+
+```text
+∀ attacker VCPU A, victim VCPU B:
+  obs(S_Microarch | execution of B) is independent of B's protected memory contents
+```
+
+This is a non-interference property. It is not implied by architectural isolation alone.
+
+## BRBE Isolation Obligations
+
+For `FEAT_BRBE` on Neoverse N2:
+
+- `BRBCR_EL1.E0BRE = 0` and `BRBCR_EL1.EXCEPTION = 0` before VM entry unless guest BRBE access is explicitly granted.
+- BRBE state is not shared across VCPU boundaries.
+- At VM exit, BRBE is either context-saved/restored or flushed.
+
+A guest that can infer EL2 branch history through BRBE violates isolation correctness and microarchitectural non-interference.


### PR DESCRIPTION
### Motivation

- Introduce a first-pass formal model of ARM virtualisation execution correctness and related invariants to capture architectures, security labels, transition systems, scanners, and worker composition. 
- Provide scaffolding for reasoning about non-interference, policy refinement, conflict closure, and a simple Galois-style compliance abstraction. 
- Ship companion documentation describing the global correctness model, EL2 control, Stage-2 isolation, SVE2 execution, KVM lifecycle, QEMU projection, threat model and Azure Cobalt constraints.

### Description

- Add Lean sources under `IATO/V7/`: `Basic.lean`, `Architecture.lean`, `ComplianceGalois.lean`, `ConflictClosure.lean`, `NonInterference.lean`, `RMETransitions.lean`, `Scanner.lean`, `SecurityLattice.lean`, and `Worker.lean` which declare core types, abbreviations, order/lattice instances, transition-system and observer views, and a number of theorems and definitions (several proofs left as `admit` and marked TODO). 
- Implement simple helpers such as `DepSet`, `SecurityLabel`, `CanFlow`, `pairwiseDisjointDeps`, `ConflictClosure` as an `OrderHom`, `scanAll`/`conflicts`, `compose` over workers and basic lemmas about joins/meets and disjointness. 
- Add extensive documentation and design artefacts: updated `README.md` and new markdown files `el2_control.md`, `stage2_isolation.md`, `sve2_execution.md`, `kvm_lifecycle.md`, `qemu_projection.md`, `threat_model.md`, `correctness_model.md`, and `cobalt_constraints.md` that capture invariants and operational contracts.

### Testing

- No automated test suite was executed as part of this change and no CI runs are included in this patch. 
- Several Lean theorems are left with `admit`/`TODO` markers, so the current sources are scaffolding rather than fully machine-checked proofs. 
- Documentation files were added and reviewed for consistency with the model, but no automated linting or spell checks were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f140767ecc83239e674089d1eb69c5)